### PR TITLE
Fix compilation issues

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -254,6 +254,7 @@ impl fmt::Display for ColumnOption {
     }
 }
 
+#[allow(clippy::needless_lifetimes)]
 fn display_constraint_name<'a>(name: &'a Option<Ident>) -> impl fmt::Display + 'a {
     struct ConstraintName<'a>(&'a Option<Ident>);
     impl<'a> fmt::Display for ConstraintName<'a> {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -480,9 +480,9 @@ impl fmt::Display for IsCheck{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             IsCheck::NULL => write!(f, "NULL"),
-            IsCheck::NULL => write!(f, "FALSE"),
-            IsCheck::NULL => write!(f, "TRUE"),
-            IsCheck::NULL => write!(f, "UNKNOWN"),
+            IsCheck::FALSE => write!(f, "FALSE"),
+            IsCheck::TRUE => write!(f, "TRUE"),
+            IsCheck::UNKNOWN => write!(f, "UNKNOWN"),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -490,6 +490,7 @@ impl fmt::Display for IsCheck{
 /// A window specification, either inline or named
 /// https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#window_clause
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum WindowSpec {
     Inline(InlineWindowSpec),
     Named(Ident),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -522,15 +522,14 @@ impl fmt::Display for InlineWindowSpec {
             write!(f, "ORDER BY {}", display_comma_separated(&self.order_by))?;
         }
         if let Some(window_frame) = &self.window_frame {
+            f.write_str(delim)?;
             if let Some(end_bound) = &window_frame.end_bound {
-                f.write_str(delim)?;
                 write!(
                     f,
                     "{} BETWEEN {} AND {}",
                     window_frame.units, window_frame.start_bound, end_bound
                 )?;
             } else {
-                f.write_str(delim)?;
                 write!(f, "{} {}", window_frame.units, window_frame.start_bound)?;
             }
         }
@@ -1355,6 +1354,7 @@ impl fmt::Display for TransactionIsolationLevel {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::large_enum_variant)]
 pub enum ShowStatementFilter {
     Like(String),
     Where(Expr),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -164,7 +164,7 @@ pub enum Expr {
     /// `IS [NOT] { NULL | FALSE | TRUE | UNKNOWN }` expression
     Is {
         expr: Box<Expr>,
-        check: &'static str,
+        check: IsCheck,
         negated: bool,
     },
     InList {
@@ -462,6 +462,27 @@ impl fmt::Display for Expr {
             Expr::Subquery(s) => write!(f, "({})", s),
             Expr::ListAgg(listagg) => write!(f, "{}", listagg),
             Expr::Struct(strct) => write!(f, "{}", strct),
+        }
+    }
+}
+
+/// An enum for Is Expr
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum IsCheck {
+    NULL,
+    FALSE,
+    TRUE,
+    UNKNOWN
+}
+
+impl fmt::Display for IsCheck{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            IsCheck::NULL => write!(f, "NULL"),
+            IsCheck::NULL => write!(f, "FALSE"),
+            IsCheck::NULL => write!(f, "TRUE"),
+            IsCheck::NULL => write!(f, "UNKNOWN"),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1091,7 +1091,6 @@ pub struct Function {
     // https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#array_agg
     /// Some(true) for IGNORE NULLS, Some(false) for RESPECT NULLS
     pub ignore_respect_nulls: Option<bool>,
-    /// Some(true) for ASC, Some(false) for DESC
     pub order_by: Vec<OrderByExpr>,
     pub limit: Option<Box<Expr>>,
     // for snowflake - this goes outside of the parens

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -468,6 +468,8 @@ impl fmt::Display for Join {
                 _ => "",
             }
         }
+        
+        #[allow(clippy::needless_lifetimes)]
         fn suffix<'a>(constraint: &'a JoinConstraint) -> impl fmt::Display + 'a {
             struct Suffix<'a>(&'a JoinConstraint);
             impl<'a> fmt::Display for Suffix<'a> {

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -146,7 +146,7 @@ pub enum DateTimeField {
     Second,
     Epoch,
     // https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#extract_2
-    Other(&'static str),
+    Other(String),
     Literal(String),
 }
 
@@ -169,7 +169,7 @@ impl fmt::Display for DateTimeField {
             DateTimeField::Minute => "MINUTE",
             DateTimeField::Second => "SECOND",
             DateTimeField::Epoch => "EPOCH",
-            DateTimeField::Other(s) => return write!(f, "{}", s),
+            DateTimeField::Other(ref s) => return write!(f, "{}", s),
             DateTimeField::Literal(ref s) => return write!(f, "'{}'", s),
         })
     }

--- a/src/dialect/ansi.rs
+++ b/src/dialect/ansi.rs
@@ -17,13 +17,13 @@ pub struct AnsiDialect {}
 
 impl Dialect for AnsiDialect {
     fn is_identifier_start(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch)
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '_'
     }
 }

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -18,13 +18,13 @@ pub struct BigQueryDialect;
 impl Dialect for BigQueryDialect {
     // see https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifiers
     fn is_identifier_start(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '_'
     }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -17,13 +17,13 @@ pub struct GenericDialect;
 
 impl Dialect for GenericDialect {
     fn is_identifier_start(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '#' || ch == '@'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '#' || ch == '@'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '@'
             || ch == '$'
             || ch == '#'

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -85,10 +85,7 @@ mod tests {
             dialect: ansi_dialect,
         };
 
-        assert_eq!(
-            dialect_of!(generic_holder is GenericDialect |  AnsiDialect),
-            true
-        );
+        assert!(dialect_of!(generic_holder is GenericDialect |  AnsiDialect));
         assert!(!dialect_of!(generic_holder is  AnsiDialect));
 
         assert!(dialect_of!(ansi_holder is  AnsiDialect));

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -89,16 +89,10 @@ mod tests {
             dialect_of!(generic_holder is GenericDialect |  AnsiDialect),
             true
         );
-        assert_eq!(dialect_of!(generic_holder is  AnsiDialect), false);
+        assert!(!dialect_of!(generic_holder is  AnsiDialect));
 
-        assert_eq!(dialect_of!(ansi_holder is  AnsiDialect), true);
-        assert_eq!(
-            dialect_of!(ansi_holder is  GenericDialect | AnsiDialect),
-            true
-        );
-        assert_eq!(
-            dialect_of!(ansi_holder is  GenericDialect | MsSqlDialect),
-            false
-        );
+        assert!(dialect_of!(ansi_holder is  AnsiDialect));
+        assert!(dialect_of!(ansi_holder is  GenericDialect | AnsiDialect));
+        assert!(!dialect_of!(ansi_holder is  GenericDialect | MsSqlDialect));
     }
 }

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -23,13 +23,13 @@ impl Dialect for MsSqlDialect {
     fn is_identifier_start(&self, ch: char) -> bool {
         // See https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-2017#rules-for-regular-identifiers
         // We don't support non-latin "letters" currently.
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '#' || ch == '@'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '#' || ch == '@'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '@'
             || ch == '$'
             || ch == '#'

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -20,15 +20,15 @@ impl Dialect for MySqlDialect {
         // See https://dev.mysql.com/doc/refman/8.0/en/identifiers.html.
         // We don't yet support identifiers beginning with numbers, as that
         // makes it hard to distinguish numeric literals.
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
             || ch == '_'
             || ch == '$'
-            || (ch >= '\u{0080}' && ch <= '\u{ffff}')
+            || ('\u{0080}'..='\u{ffff}').contains(&ch)
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        self.is_identifier_start(ch) || (ch >= '0' && ch <= '9')
+        self.is_identifier_start(ch) || ('0'..='9').contains(&ch)
     }
 
     fn is_delimited_identifier_start(&self, ch: char) -> bool {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -20,13 +20,13 @@ impl Dialect for PostgreSqlDialect {
         // See https://www.postgresql.org/docs/11/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
         // We don't yet support identifiers beginning with "letters with
         // diacritical marks and non-Latin letters"
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '$'
             || ch == '_'
     }

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -21,13 +21,13 @@ impl Dialect for SnowflakeDialect {
     // querying stages:
     // https://docs.snowflake.com/en/user-guide/querying-stage.html#query-syntax-and-parameters
     fn is_identifier_start(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '$'
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch) || ch == '_' || ch == '$'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= '0' && ch <= '9')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
             || ch == '$'
             || ch == '_'
     }

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -25,14 +25,14 @@ impl Dialect for SQLiteDialect {
 
     fn is_identifier_start(&self, ch: char) -> bool {
         // See https://www.sqlite.org/draft/tokenreq.html
-        (ch >= 'a' && ch <= 'z')
-            || (ch >= 'A' && ch <= 'Z')
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
             || ch == '_'
             || ch == '$'
-            || (ch >= '\u{007f}' && ch <= '\u{ffff}')
+            || ('\u{007f}'..='\u{ffff}').contains(&ch)
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        self.is_identifier_start(ch) || (ch >= '0' && ch <= '9')
+        self.is_identifier_start(ch) || ('0'..='9').contains(&ch)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -938,10 +938,10 @@ impl<'a> Parser<'a> {
                 Keyword::IS => {
                     let negated = self.parse_keyword(Keyword::NOT);
                     let check = match self.next_token() {
-                        Token::Word(w) if w.keyword == Keyword::NULL => "NULL",
-                        Token::Word(w) if w.keyword == Keyword::FALSE => "FALSE",
-                        Token::Word(w) if w.keyword == Keyword::TRUE => "TRUE",
-                        Token::Word(w) if w.keyword == Keyword::UNKNOWN => "UNKNOWN",
+                        Token::Word(w) if w.keyword == Keyword::NULL => IsCheck::NULL,
+                        Token::Word(w) if w.keyword == Keyword::FALSE => IsCheck::FALSE,
+                        Token::Word(w) if w.keyword == Keyword::TRUE => IsCheck::TRUE,
+                        Token::Word(w) if w.keyword == Keyword::UNKNOWN => IsCheck::UNKNOWN,
                         unexpected => {
                             return self.expected("NULL, FALSE, TRUE, or UNKNOWN", unexpected)
                         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -708,10 +708,10 @@ impl<'a> Parser<'a> {
                 | Keyword::WEEKOFYEAR
                 | Keyword::WOY
                 | Keyword::WY => Ok(DateTimeField::Week(None)),
-                Keyword::ISOWEEK => Ok(DateTimeField::Other("ISOWEEK")),
-                Keyword::ISOYEAR => Ok(DateTimeField::Other("ISOYEAR")),
-                Keyword::MICROSECOND => Ok(DateTimeField::Other("MICROSECOND")),
-                Keyword::MILLISECOND => Ok(DateTimeField::Other("MILLISECOND")),
+                Keyword::ISOWEEK => Ok(DateTimeField::Other("ISOWEEK".to_owned())),
+                Keyword::ISOYEAR => Ok(DateTimeField::Other("ISOYEAR".to_owned())),
+                Keyword::MICROSECOND => Ok(DateTimeField::Other("MICROSECOND".to_owned())),
+                Keyword::MILLISECOND => Ok(DateTimeField::Other("MILLISECOND".to_owned())),
                 Keyword::WEEKISO
                 | Keyword::WEEK_ISO
                 | Keyword::WEEKOFYEARISO
@@ -729,8 +729,8 @@ impl<'a> Parser<'a> {
                 Keyword::DAYOFYEAR | Keyword::YEARDAY | Keyword::DOY | Keyword::DY => {
                     Ok(DateTimeField::DayOfYear)
                 }
-                Keyword::DATE => Ok(DateTimeField::Other("DATE")),
-                Keyword::DATETIME => Ok(DateTimeField::Other("DATETIME")),
+                Keyword::DATE => Ok(DateTimeField::Other("DATE".to_owned())),
+                Keyword::DATETIME => Ok(DateTimeField::Other("DATETIME".to_owned())),
                 Keyword::HOUR => Ok(DateTimeField::Hour),
                 Keyword::MINUTE => Ok(DateTimeField::Minute),
                 Keyword::SECOND => Ok(DateTimeField::Second),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -64,7 +64,7 @@ impl TestedDialects {
     }
 
     pub fn parse_sql_statements(&self, sql: &str) -> Result<Vec<Statement>, ParserError> {
-        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, &sql))
+        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, sql))
         // To fail the `ensure_multiple_dialects_are_tested` test:
         // Parser::parse_sql(&**self.dialects.first().unwrap(), sql)
     }
@@ -75,11 +75,11 @@ impl TestedDialects {
     /// tree as parsing `canonical`, and that serializing it back to string
     /// results in the `canonical` representation.
     pub fn one_statement_parses_to(&self, sql: &str, canonical: &str) -> Statement {
-        let mut statements = self.parse_sql_statements(&sql).unwrap();
+        let mut statements = self.parse_sql_statements(sql).unwrap();
         assert_eq!(statements.len(), 1);
 
         if !canonical.is_empty() && sql != canonical {
-            assert_eq!(self.parse_sql_statements(&canonical).unwrap(), statements);
+            assert_eq!(self.parse_sql_statements(canonical).unwrap(), statements);
         }
 
         let only_statement = statements.pop().unwrap();

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -212,7 +212,7 @@ fn parse_top_level() {
 fn parse_simple_select() {
     let sql = "SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5";
     let select = verified_only_select(sql);
-    assert_eq!(false, select.distinct);
+    assert!(!select.distinct);
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
     assert_eq!(Some(Expr::Value(number("5"))), select.limit);
@@ -1206,9 +1206,9 @@ fn parse_assert_message() {
     match ast {
         Statement::Assert {
             condition: _condition,
-            message: Some(Expr::Value::SingleQuotedString(s)),
+            message: Some(Expr::Value(Value::SingleQuotedString(s))),
         } => {
-            assert_eq!(s, "No rows in my_table"),
+            assert_eq!(s, "No rows in my_table")
         }
         _ => unreachable!(),
     }
@@ -2796,13 +2796,13 @@ fn parse_drop_table() {
             names,
             cascade,
         } => {
-            assert_eq!(false, if_exists);
+            assert!(!if_exists);
             assert_eq!(ObjectType::Table, object_type);
             assert_eq!(
                 vec!["foo"],
                 names.iter().map(ToString::to_string).collect::<Vec<_>>()
             );
-            assert_eq!(false, cascade);
+            assert!(!cascade);
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -303,7 +303,7 @@ fn parse_column_aliases() {
     }
 
     // alias without AS is parsed correctly:
-    one_statement_parses_to("SELECT a.col + 1 newname FROM foo AS a", &sql);
+    one_statement_parses_to("SELECT a.col + 1 newname FROM foo AS a", sql);
 }
 
 #[test]
@@ -2566,7 +2566,7 @@ fn parse_multiple_statements() {
         let res = parse_sql_statements(&(sql1.to_owned() + ";" + sql2_kw + sql2_rest));
         assert_eq!(
             vec![
-                one_statement_parses_to(&sql1, ""),
+                one_statement_parses_to(sql1, ""),
                 one_statement_parses_to(&(sql2_kw.to_owned() + sql2_rest), ""),
             ],
             res.unwrap()

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -232,7 +232,7 @@ fn parse_limit_is_not_an_alias() {
 fn parse_select_distinct() {
     let sql = "SELECT DISTINCT name FROM customer";
     let select = verified_only_select(sql);
-    assert_eq!(true, select.distinct);
+    assert!(select.distinct);
     assert_eq!(
         &SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("name"))),
         only(&select.projection)
@@ -1206,12 +1206,9 @@ fn parse_assert_message() {
     match ast {
         Statement::Assert {
             condition: _condition,
-            message: Some(message),
+            message: Some(Expr::Value::SingleQuotedString(s)),
         } => {
-            match message {
-                Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in my_table"),
-                _ => unreachable!(),
-            };
+            assert_eq!(s, "No rows in my_table"),
         }
         _ => unreachable!(),
     }
@@ -1582,8 +1579,8 @@ fn parse_alter_table_drop_column() {
             } => {
                 assert_eq!("tab", name.to_string());
                 assert_eq!("is_active", column_name.to_string());
-                assert_eq!(true, if_exists);
-                assert_eq!(true, cascade);
+                assert!(if_exists);
+                assert!(cascade);
             }
             _ => unreachable!(),
         }
@@ -2818,13 +2815,13 @@ fn parse_drop_table() {
             names,
             cascade,
         } => {
-            assert_eq!(true, if_exists);
+            assert!(if_exists);
             assert_eq!(ObjectType::Table, object_type);
             assert_eq!(
                 vec!["foo", "bar"],
                 names.iter().map(ToString::to_string).collect::<Vec<_>>()
             );
-            assert_eq!(true, cascade);
+            assert!(cascade);
         }
         _ => unreachable!(),
     }
@@ -3259,8 +3256,8 @@ fn parse_create_index() {
             assert_eq!("idx_name", name.to_string());
             assert_eq!("test", table_name.to_string());
             assert_eq!(indexed_columns, columns);
-            assert_eq!(true, unique);
-            assert_eq!(true, if_not_exists)
+            assert!(unique);
+            assert!(if_not_exists)
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -280,25 +280,25 @@ fn parse_create_table_if_not_exists() {
 fn parse_bad_if_not_exists() {
     let res = pg().parse_sql_statements("CREATE TABLE NOT EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError("".to_string(), "Expected end of statement, found: EXISTS".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF EXISTS uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: EXISTS".to_string()),
+        ParserError::ParserError("".to_string(), "Expected end of statement, found: EXISTS".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: uk_cities".to_string()),
+        ParserError::ParserError("".to_string(), "Expected end of statement, found: uk_cities".to_string()),
         res.unwrap_err()
     );
 
     let res = pg().parse_sql_statements("CREATE TABLE IF NOT uk_cities ()");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: NOT".to_string()),
+        ParserError::ParserError("".to_string(), "Expected end of statement, found: NOT".to_string()),
         res.unwrap_err()
     );
 }
@@ -414,21 +414,21 @@ fn parse_set() {
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET"),
-        Err(ParserError::ParserError(
+        Err(ParserError::ParserError("".to_string(), 
             "Expected identifier, found: EOF".to_string()
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a b"),
-        Err(ParserError::ParserError(
+        Err(ParserError::ParserError("".to_string(), 
             "Expected equals sign or TO, found: b".to_string()
         )),
     );
 
     assert_eq!(
         pg_and_generic().parse_sql_statements("SET a ="),
-        Err(ParserError::ParserError(
+        Err(ParserError::ParserError("".to_string(), 
             "Expected variable value, found: EOF".to_string()
         )),
     );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -38,7 +38,7 @@ fn test_snowflake_create_table() {
 fn test_snowflake_single_line_tokenize() {
     let sql = "CREATE TABLE# this is a comment \ntable_1";
     let dialect = SnowflakeDialect {};
-    let mut tokenizer = Tokenizer::new(&dialect, &sql);
+    let mut tokenizer = Tokenizer::new(&dialect, sql);
     let tokens = tokenizer.tokenize().unwrap();
 
     let expected = vec![
@@ -55,7 +55,7 @@ fn test_snowflake_single_line_tokenize() {
     assert_eq!(expected, tokens);
 
     let sql = "CREATE TABLE// this is a comment \ntable_1";
-    let mut tokenizer = Tokenizer::new(&dialect, &sql);
+    let mut tokenizer = Tokenizer::new(&dialect, sql);
     let tokens = tokenizer.tokenize().unwrap();
 
     let expected = vec![

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -133,13 +133,13 @@ fn test_single_table_in_parenthesis_with_alias() {
 
     let res = snowflake_and_generic().parse_sql_statements("SELECT * FROM (a NATURAL JOIN b) c");
     assert_eq!(
-        ParserError::ParserError("Expected end of statement, found: c".to_string()),
+        ParserError::ParserError("".to_string(), "Expected end of statement, found: c".to_string()),
         res.unwrap_err()
     );
 
     let res = snowflake().parse_sql_statements("SELECT * FROM (a b) c");
     assert_eq!(
-        ParserError::ParserError("duplicate alias b".to_string()),
+        ParserError::ParserError("".to_string(), "duplicate alias b".to_string()),
         res.unwrap_err()
     );
 }


### PR DESCRIPTION
Refer to commit history for more chronological information.

High-level
1. Addressed two issues with `&'static str` and changed it to . This resolves most of the `'de` lifetime issues.
2. Blanket "fixed" ParserError types by just giving an empty string as the first argument. This only fixes the compilation errors. The tests will still fail and will be addressed in a later date.
3. Fix some other type changes. 