### PR TITLE
db dialect, backtick mod

### DIFF
--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::dialect::Dialect;
+
+#[derive(Debug)]
+pub struct DatabricksDialect {}
+
+// derived from AnsiDialect, but modified with backtick identifier
+impl Dialect for DatabricksDialect {
+    fn is_identifier_start(&self, ch: char) -> bool {
+        ('a'..='z').contains(&ch) || ('A'..='Z').contains(&ch)
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        ('a'..='z').contains(&ch)
+            || ('A'..='Z').contains(&ch)
+            || ('0'..='9').contains(&ch)
+            || ch == '_'
+    }
+
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '`'
+    }
+}

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -12,6 +12,7 @@
 
 mod ansi;
 mod bigquery;
+mod databricks;
 mod generic;
 pub mod keywords;
 mod mssql;
@@ -25,6 +26,7 @@ use std::fmt::Debug;
 
 pub use self::ansi::AnsiDialect;
 pub use self::bigquery::BigQueryDialect;
+pub use self::databricks::DatabricksDialect;
 pub use self::generic::GenericDialect;
 pub use self::mssql::MsSqlDialect;
 pub use self::mysql::MySqlDialect;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2072,7 +2072,10 @@ impl<'a> Parser<'a> {
             //    ignore the <separator> and treat the multiple strings as
             //    a single <literal>."
             Token::SingleQuotedString(s) => Ok(Some(Ident::with_quote('\'', s))),
-            Token::BacktickQuotedString(s) if dialect_of!(self is BigQueryDialect) => {
+            Token::BacktickQuotedString(s)
+                if dialect_of!(self is BigQueryDialect)
+                    || dialect_of!(self is DatabricksDialect) =>
+            {
                 Ok(Some(Ident::with_quote('`', s)))
             }
             not_an_ident => {


### PR DESCRIPTION
This adds a `DatabricksDialect` module and specifies backticks as a delimiter for the dialect