### PR TITLE
[SIG-43218] support for snowflake EXCLUDE wildcard modifier

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -228,6 +228,7 @@ pub enum SelectItem {
     Wildcard {
         prefix: Option<ObjectName>,
         except: Vec<Ident>,
+        exclude: Vec<Ident>, // Snowflake's flavor of EXCEPT
         replace: Vec<(Expr, Ident)>,
     },
 }
@@ -240,6 +241,7 @@ impl fmt::Display for SelectItem {
             SelectItem::Wildcard {
                 prefix,
                 except,
+                exclude,
                 replace,
             } => {
                 if let Some(pre) = prefix {
@@ -249,14 +251,26 @@ impl fmt::Display for SelectItem {
                 }
                 let mut delim = "";
                 if !except.is_empty() {
-                    write!(f, " EXCEPT (")?;
+                    write!(f, " EXCEPT ")?;
                     for col in except {
                         write!(f, "{}{}", delim, col)?;
                         delim = ", ";
                     }
-                    write!(f, ")")?;
                 }
                 delim = "";
+                if !exclude.is_empty() {
+                    write!(f, " EXCLUDE ")?;
+                    if exclude.len() == 1 {
+                        write!(f, "{}", exclude[0])?;
+                    } else {
+                        write!(f, "(")?;
+                        for col in exclude {
+                            write!(f, "{}{}", delim, col)?;
+                            delim = ", ";
+                        }
+                        write!(f, ")")?;
+                    }
+                }
                 if !replace.is_empty() {
                     write!(f, " REPLACE (")?;
                     for &(ref expr, ref alias) in replace.iter() {

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -201,6 +201,7 @@ define_keywords!(
     ESCAPE,
     EVERY,
     EXCEPT,
+    EXCLUDE,
     EXEC,
     EXECUTE,
     EXISTS,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,6 +28,7 @@ pub enum ParserError {
 }
 
 pub type WildcardExcept = Vec<Ident>;
+pub type WildcardExclude = Vec<Ident>;
 pub type WildcardReplace = Vec<(Expr, Ident)>;
 
 // Use `Parser::expected` instead, if possible
@@ -2871,17 +2872,19 @@ impl<'a> Parser<'a> {
     pub fn parse_select_item(&mut self) -> Result<SelectItem, ParserError> {
         let expr = self.parse_expr()?;
         if let Expr::Wildcard = expr {
-            let (except, replace) = self.parse_wildcard_modifiers()?;
+            let (except, exclude, replace) = self.parse_wildcard_modifiers()?;
             Ok(SelectItem::Wildcard {
                 prefix: None,
                 except,
+                exclude,
                 replace,
             })
         } else if let Expr::QualifiedWildcard(prefix) = expr {
-            let (except, replace) = self.parse_wildcard_modifiers()?;
+            let (except, exclude, replace) = self.parse_wildcard_modifiers()?;
             Ok(SelectItem::Wildcard {
                 prefix: Some(ObjectName(prefix)),
                 except,
+                exclude,
                 replace,
             })
         } else {
@@ -2908,7 +2911,7 @@ impl<'a> Parser<'a> {
 
     pub fn parse_wildcard_modifiers(
         &mut self,
-    ) -> Result<(WildcardExcept, WildcardReplace), ParserError> {
+    ) -> Result<(WildcardExcept, WildcardExclude, WildcardReplace), ParserError> {
         let except = if self.parse_keyword(Keyword::EXCEPT) {
             self.expect_token(&Token::LParen)?;
             let aliases = self.parse_comma_separated(Parser::parse_identifier)?;
@@ -2917,7 +2920,18 @@ impl<'a> Parser<'a> {
         } else {
             vec![]
         };
-        let replace = if self.parse_keyword(Keyword::EXCEPT) {
+        let exclude = if self.parse_keyword(Keyword::EXCLUDE) {
+            if self.consume_token(&Token::LParen) {
+                let aliases = self.parse_comma_separated(Parser::parse_identifier)?;
+                self.expect_token(&Token::RParen)?;
+                aliases
+            } else {
+                vec![self.parse_identifier()?]
+            }
+        } else {
+            vec![]
+        };
+        let replace = if self.parse_keyword(Keyword::REPLACE) {
             self.expect_token(&Token::LParen)?;
             let replace = self.parse_comma_separated(Parser::parse_replace_item)?;
             self.expect_token(&Token::RParen)?;
@@ -2925,7 +2939,7 @@ impl<'a> Parser<'a> {
         } else {
             vec![]
         };
-        Ok((except, replace))
+        Ok((except, exclude, replace))
     }
 
     /// Parse an expression, optionally followed by ASC or DESC (used in ORDER BY)

--- a/tests/queries/snowflake/wildcard_modifiers_exclude.sql
+++ b/tests/queries/snowflake/wildcard_modifiers_exclude.sql
@@ -1,0 +1,6 @@
+SELECT
+  table_a.* EXCLUDE foo,
+  table_b.* EXCLUDE (bar, baz)
+FROM
+  table_a,
+  table_b

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -273,6 +273,7 @@ fn parse_select_wildcard() {
         &SelectItem::Wildcard {
             prefix: None,
             except: vec![],
+            exclude: vec![],
             replace: vec![]
         },
         only(&select.projection)
@@ -284,6 +285,7 @@ fn parse_select_wildcard() {
         &SelectItem::Wildcard {
             prefix: Some(ObjectName(vec![Ident::new("foo")])),
             except: vec![],
+            exclude: vec![],
             replace: vec![]
         },
         only(&select.projection)
@@ -298,6 +300,7 @@ fn parse_select_wildcard() {
                 Ident::new("mytable"),
             ])),
             except: vec![],
+            exclude: vec![],
             replace: vec![]
         },
         only(&select.projection)

--- a/tests/sqlparser_regression.rs
+++ b/tests/sqlparser_regression.rs
@@ -15,50 +15,67 @@
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
-macro_rules! tpch_tests {
-    ($($name:ident: $value:expr,)*) => {
-        const QUERIES: &[&str] = &[
-            $(include_str!(concat!("queries/tpch/", $value, ".sql"))),*
-        ];
+macro_rules! regression_tests {
+    (
+        path: $path:literal,
+        tests: [$(
+            $(#[$attr:ident])?
+            $name:ident: $file:expr,
+        )*] $(,)?
+    ) => {
     $(
 
         #[test]
+        $(#[$attr])?
         fn $name() {
             let dialect = GenericDialect {};
 
-            let res = Parser::parse_sql(&dialect, QUERIES[$value -1]);
-            // Ignore 6.sql and 22.sql
-            if $value != 6 && $value != 22 {
-                assert!(res.is_ok());
+            let stmts = Parser::parse_sql(&dialect, include_str!(concat!($path, $file, ".sql")))
+                .unwrap_or_else(|err| panic!("{}", err));
+
+            // check that each statement still parses after being rendered
+            for stmt in stmts {
+                assert!(Parser::parse_sql(&dialect, &dbg!(stmt.to_string())).is_ok());
             }
         }
     )*
     }
 }
 
-tpch_tests! {
-    tpch_1: 1,
-    tpch_2: 2,
-    tpch_3: 3,
-    tpch_4: 4,
-    tpch_5: 5,
-    tpch_6: 6,
-    tpch_7: 7,
-    tpch_8: 8,
-    tpch_9: 9,
-    tpch_10: 10,
-    tpch_11: 11,
-    tpch_12: 12,
-    tpch_13: 13,
-    tpch_14: 14,
-    tpch_15: 15,
-    tpch_16: 16,
-    tpch_17: 17,
-    tpch_18: 18,
-    tpch_19: 19,
-    tpch_20: 20,
-    tpch_21: 21,
-    tpch_22: 22,
-    tpch_23: 23,
-    tpch_24: 24,
+regression_tests! {
+    path: "queries/tpch/",
+    tests: [
+        tpch_1: "1",
+        tpch_2: "2",
+        tpch_3: "3",
+        tpch_4: "4",
+        tpch_5: "5",
+        tpch_6: "6",
+        tpch_7: "7",
+        tpch_8: "8",
+        tpch_9: "9",
+        tpch_10: "10",
+        tpch_11: "11",
+        tpch_12: "12",
+        tpch_13: "13",
+        tpch_14: "14",
+        tpch_15: "15",
+        tpch_16: "16",
+        tpch_17: "17",
+        tpch_18: "18",
+        tpch_19: "19",
+        tpch_20: "20",
+        tpch_21: "21",
+        #[ignore]
+        tpch_22: "22",
+        tpch_23: "23",
+        tpch_24: "24",
+    ],
+}
+
+regression_tests! {
+    path: "queries/snowflake//",
+    tests: [
+        snowflake_wildcard_modifiers_exclude: "wildcard_modifiers_exclude",
+    ],
 }

--- a/tests/sqlparser_sigma.rs
+++ b/tests/sqlparser_sigma.rs
@@ -1428,6 +1428,7 @@ fn parse_complicated_sql() {
                                         quote_style: None,
                                     }])),
                                     except: vec![],
+                                    exclude: vec![],
                                     replace: vec![],
                                 },
                                 ExprWithAlias {
@@ -2044,6 +2045,7 @@ fn parse_complicated_sql() {
                                 SelectItem::Wildcard {
                                     prefix: None,
                                     except: vec![],
+                                    exclude: vec![],
                                     replace: vec![],
                                 },
                                 ExprWithAlias {
@@ -2120,6 +2122,7 @@ fn parse_complicated_sql() {
                                         quote_style: None,
                                     }])),
                                     except: vec![],
+                                    exclude: vec![],
                                     replace: vec![],
                                 },
                                 ExprWithAlias {
@@ -2640,6 +2643,7 @@ fn parse_complicated_sql() {
                                         quote_style: None,
                                     }])),
                                     except: vec![],
+                                    exclude: vec![],
                                     replace: vec![],
                                 },
                                 ExprWithAlias {
@@ -2764,6 +2768,7 @@ fn parse_complicated_sql() {
                         quote_style: None,
                     }])),
                     except: vec![],
+                    exclude: vec![],
                     replace: vec![],
                 },
                 ExprWithAlias {


### PR DESCRIPTION
Snowflake supports a special syntax `EXCLUDE` on wildcard select items. This PR adds support for this syntax, so that these queries can be parsed and rendered.