### PR TITLE
[SIG-43614] Fix SQL parsing for select statement as function argument

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1221,8 +1221,7 @@ impl<'a> Parser<'a> {
 
     /// Return the first unprocessed token, possibly whitespace.
     pub fn next_token_no_skip(&mut self) -> Option<&Token> {
-        self.index += 1;
-        self.tokens.get(self.index - 1)
+        self.tokens.get(self.index)
     }
 
     /// Push back the last one non-whitespace token. Must be called after

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1220,8 +1220,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Return the first unprocessed token, possibly whitespace.
+    /// FIXME: This function skips the token
     pub fn next_token_no_skip(&mut self) -> Option<&Token> {
-        self.tokens.get(self.index)
+        self.index += 1;
+        self.tokens.get(self.index - 1)
     }
 
     /// Push back the last one non-whitespace token. Must be called after

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2775,8 +2775,6 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_function_args(&mut self) -> Result<FunctionArg, ParserError> {
-
-        
         if self.peek_nth_token(1) == Token::RArrow {
             let name = self.parse_identifier()?;
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -177,15 +177,16 @@ fn parse_select_as_func_argument() {
         "SELECT func((WITH foo AS (SELECT 1) SELECT 1))",
     );
 
-        // named function arguments should not work
-        assert_eq!(snowflake().parse_sql_statements(
-            "SELECT func(expr => SELECT 1)",
-           
-        ).unwrap_err(),
+    // named function arguments should not work
+    let res = snowflake().parse_sql_statements(
+        "SELECT func(expr => SELECT 1)",
+    );
+    assert_eq!(
+        res.unwrap_err(),
         ParserError::ParserError(
             "SELECT func(expr => SELECT".to_string(),
             "Expected ), found: 1".to_string()
-        ));
+    ));
 }
 
 fn snowflake() -> TestedDialects {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -151,6 +151,43 @@ fn test_single_table_in_parenthesis_with_alias() {
     );
 }
 
+
+#[test]
+fn parse_select_as_func_argument() {
+    // subquery without parantheses in function call should work
+    snowflake().one_statement_parses_to(
+        "SELECT parse_json(SELECT column2 FROM values(1, 'null'))",
+        "SELECT parse_json((SELECT column2 FROM values(1, 'null')))",
+    );
+    // subquery with parantheses in function call should also work
+    snowflake().one_statement_parses_to(
+        "SELECT parse_json((SELECT column2 FROM values(1, 'null')))",
+        "SELECT parse_json((SELECT column2 FROM values(1, 'null')))",
+    );
+     // subquery with comma in function call should be interpreted as function with one argument
+     // Ex: func(select 1, 2) === fun((select 1, 2))
+    snowflake().one_statement_parses_to(
+        "SELECT func(SELECT 1, 2)",
+        "SELECT func((SELECT 1, 2))",
+    );
+
+    // subquery starting with WITH should also work
+    snowflake().one_statement_parses_to(
+        "SELECT func(WITH foo AS (SELECT 1) SELECT 1)",
+        "SELECT func((WITH foo AS (SELECT 1) SELECT 1))",
+    );
+
+        // named function arguments should not work
+        assert_eq!(snowflake().parse_sql_statements(
+            "SELECT func(expr => SELECT 1)",
+           
+        ).unwrap_err(),
+        ParserError::ParserError(
+            "SELECT func(expr => SELECT".to_string(),
+            "Expected ), found: 1".to_string()
+        ));
+}
+
 fn snowflake() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(SnowflakeDialect {})],


### PR DESCRIPTION
we were failing to parse `SELECT parse_json(SELECT column2 FROM values(1, 'null'))` even though it is valid sql. This was happening because the parser expects every `SELECT` subquery to be enclosed by parentheses (hence, in a function call, by 2). This assumption is incorrect, and even the test added to confirm this is only a false positive. For example, `SELECT SELECT column2` actually succeeds. 

This PR disables the `parse_invalid_subquery_without_parens`, fixes the sql parsing issue and adds a test for it.

Confirmed on local qwill that the sql does not fail anymore.
```
WITH 
  venue_list as ( 
    select 
      TO_CHAR ( 
        ARRAY_CONSTRUCT_COMPACT ( 
          {{ venue_one }}, 
          {{ venue_two }}, 
          {{ venue_three }}, 
          {{ venue_four }}, 
          {{ venue_five }} 
        ) 
      ) as property 
  ), 
  query_one AS ( 
    select distinct 
      value as property 
    from 
      TABLE ( 
        FLATTEN ( 
          input => parse_json ( 
            select 
              property 
            from 
              venue_list 
          ) 
        ) 
      ) 
  ) 
SELECT 
  qo.property::string AS row_venue, 
  qt.property::string AS column_venue 
FROM 
  query_one AS qo 
  CROSS JOIN query_one AS qt

```