### PR TITLE
[SIG-45721] don't interpret QUALIFY as table alias

### DIFF
--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -559,6 +559,8 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::USING,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)
     Keyword::OUTER,
+    // for Snowflake QUALIFY
+    Keyword::QUALIFY,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`


### PR DESCRIPTION
Small fix for a customer issue. I didn't bother adding a test because this is fixed and has a test upstream, and we'll be rebasing against that soon.