### PR TITLE
support for SELECT TOP on snowflake

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -30,7 +30,8 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     Cte, Fetch, Join, JoinConstraint, JoinOperator, Offset, OffsetRows, OrderByExpr, Query, Select,
-    SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top, Values, With,
+    SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top, TopQuantity,
+    Values, With,
 };
 pub use self::value::{DateTimeField, Value};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2983,9 +2983,14 @@ impl<'a> Parser<'a> {
         let quantity = if self.consume_token(&Token::LParen) {
             let quantity = self.parse_expr()?;
             self.expect_token(&Token::RParen)?;
-            Some(quantity)
+            Some(TopQuantity::Expr(quantity))
         } else {
-            Some(self.parse_number_value_or_ident()?)
+            let next_token = self.next_token();
+            let quantity = match next_token {
+                Token::Number(s) => s.parse::<u64>().expect("literal int"),
+                _ => self.expected("literal int", next_token)?,
+            };
+            Some(TopQuantity::Constant(quantity))
         };
 
         let percent = self.parse_keyword(Keyword::PERCENT);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -76,7 +76,10 @@ fn parse_mssql_top_paren() {
     let sql = "SELECT TOP (5) * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
-    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert_eq!(
+        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        top.quantity
+    );
     assert!(!top.percent);
 }
 
@@ -85,7 +88,10 @@ fn parse_mssql_top_percent() {
     let sql = "SELECT TOP (5) PERCENT * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
-    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert_eq!(
+        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        top.quantity
+    );
     assert!(top.percent);
 }
 
@@ -94,7 +100,10 @@ fn parse_mssql_top_with_ties() {
     let sql = "SELECT TOP (5) WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
-    assert_eq!(Some(Expr::Value(number("5"))), top.quantity);
+    assert_eq!(
+        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        top.quantity
+    );
     assert!(top.with_ties);
 }
 
@@ -103,14 +112,17 @@ fn parse_mssql_top_percent_with_ties() {
     let sql = "SELECT TOP (10) PERCENT WITH TIES * FROM foo";
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
-    assert_eq!(Some(Expr::Value(number("10"))), top.quantity);
+    assert_eq!(
+        Some(TopQuantity::Expr(Expr::Value(number("10")))),
+        top.quantity
+    );
     assert!(top.percent);
 }
 
 #[test]
 fn parse_mssql_top() {
     let sql = "SELECT TOP 5 bar, baz FROM foo";
-    let _ = ms_and_generic().one_statement_parses_to(sql, "SELECT TOP (5) bar, baz FROM foo");
+    let _ = ms_and_generic().one_statement_parses_to(sql, "SELECT TOP 5 bar, baz FROM foo");
 }
 
 fn ms() -> TestedDialects {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -200,3 +200,11 @@ fn snowflake_and_generic() -> TestedDialects {
         dialects: vec![Box::new(SnowflakeDialect {}), Box::new(GenericDialect {})],
     }
 }
+
+#[test]
+fn parse_top() {
+    snowflake().one_statement_parses_to(
+        "SELECT TOP 4 c1 FROM testtable",
+        "SELECT TOP 4 c1 FROM testtable",
+    );
+}


### PR DESCRIPTION
The parser currently accepts Snowflake `SELECT TOP` syntax, but then it renders it using MSSQL syntax (where the expression is parenthesized), which causes the resultant queries to fail in Snowflake with syntax errors. This PR fixes the issue. 