### PR TITLE
fix: have wildcard replace work in duckdb and snowflake syntax

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8793,7 +8793,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect)
+        let opt_replace = if dialect_of!(self is GenericDialect | BigQueryDialect | ClickHouseDialect | SnowflakeDialect | DuckDbDialect)
         {
             self.parse_optional_select_item_replace()?
         } else {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1593,3 +1593,25 @@ fn parse_connect_by() {
         )))]
     );
 }
+
+#[test]
+fn test_select_wildcard_with_replace() {
+    let select = snowflake_and_generic().verified_only_select(
+        r#"SELECT * REPLACE ('DEPT-' || department_id AS department_id) FROM tbl"#,
+    );
+    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
+        opt_replace: Some(ReplaceSelectItem {
+            items: vec![Box::new(ReplaceSelectElement {
+                expr: Expr::BinaryOp {
+                    left: Box::new(Expr::Value(Value::SingleQuotedString("DEPT-".to_owned()))),
+                    op: BinaryOperator::StringConcat,
+                    right: Box::new(Expr::Identifier(Ident::new("department_id"))),
+                },
+                column_name: Ident::new("department_id"),
+                as_keyword: true,
+            })],
+        }),
+        ..Default::default()
+    });
+    assert_eq!(expected, select.projection[0]);
+}


### PR DESCRIPTION
This address https://sigmacomputing.atlassian.net/browse/SIG-52729.

The syntax that broke was `SELECT * REPLACE() from table`. The functionality already existed, needed to be enabled for Snowflake and DuckDB. 

I added test cases so that the examples given in the respective documentation passed: 
duck db: https://duckdb.org/docs/sql/query_syntax/select.html
snowflake: https://docs.snowflake.com/en/sql-reference/sql/select