### PR TITLE
feat: implement wildcard select ilike

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -40,8 +40,8 @@ pub use self::ddl::{
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
     ConnectBy, Cte, CteAsMaterialized, Distinct, ExceptSelectItem, ExcludeSelectItem, Fetch,
-    ForClause, ForJson, ForXml, GroupByExpr, IdentWithAlias, Join, JoinConstraint, JoinOperator,
-    JsonTableColumn, JsonTableColumnErrorHandling, LateralView, LockClause, LockType,
+    ForClause, ForJson, ForXml, GroupByExpr, IdentWithAlias, IlikeSelectItem, Join, JoinConstraint,
+    JoinOperator, JsonTableColumn, JsonTableColumnErrorHandling, LateralView, LockClause, LockType,
     NamedWindowDefinition, NonBlock, Offset, OffsetRows, OrderByExpr, Query, RenameSelectItem,
     ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SetOperator,
     SetQuantifier, Table, TableAlias, TableFactor, TableVersion, TableWithJoins, Top, TopQuantity,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -524,12 +524,12 @@ impl fmt::Display for WildcardAdditionalOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct IlikeSelectItem {
-    pub pattern: Expr,
+    pub pattern: String,
 }
 
 impl fmt::Display for IlikeSelectItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ILIKE {}", self.pattern)?;
+        write!(f, "ILIKE '{}'", self.pattern)?;
         Ok(())
     }
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -477,6 +477,9 @@ impl fmt::Display for IdentWithAlias {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct WildcardAdditionalOptions {
+    /// `[ILIKE...]`.
+    /// Snowflake syntax: <https://docs.snowflake.com/en/sql-reference/sql/select>
+    pub opt_ilike: Option<IlikeSelectItem>,
     /// `[EXCLUDE...]`.
     pub opt_exclude: Option<ExcludeSelectItem>,
     /// `[EXCEPT...]`.
@@ -492,6 +495,9 @@ pub struct WildcardAdditionalOptions {
 
 impl fmt::Display for WildcardAdditionalOptions {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ilike) = &self.opt_ilike {
+            write!(f, " {ilike}")?;
+        }
         if let Some(exclude) = &self.opt_exclude {
             write!(f, " {exclude}")?;
         }
@@ -508,6 +514,25 @@ impl fmt::Display for WildcardAdditionalOptions {
     }
 }
 
+/// Snowflake `ILIKE` information.
+///
+/// # Syntax
+/// ```plaintext
+/// ILIKE <value>
+/// ```
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct IlikeSelectItem {
+    pub pattern: Expr,
+}
+
+impl fmt::Display for IlikeSelectItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ILIKE {}", self.pattern)?;
+        Ok(())
+    }
+}
 /// Snowflake `EXCLUDE` information.
 ///
 /// # Syntax

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -529,7 +529,11 @@ pub struct IlikeSelectItem {
 
 impl fmt::Display for IlikeSelectItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ILIKE '{}'", self.pattern)?;
+        write!(
+            f,
+            "ILIKE '{}'",
+            value::escape_single_quote_string(&self.pattern)
+        )?;
         Ok(())
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8780,7 +8780,7 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        let opt_exclude = if !opt_ilike.is_some()
+        let opt_exclude = if opt_ilike.is_none()
             && dialect_of!(self is GenericDialect | DuckDbDialect | SnowflakeDialect)
         {
             self.parse_optional_select_item_exclude()?

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8822,7 +8822,7 @@ impl<'a> Parser<'a> {
             let next_token = self.next_token();
             let pattern = match next_token.token {
                 Token::SingleQuotedString(s) => Ok(s),
-                _ => self.expected("single quoted string", next_token),
+                _ => self.expected("ilike pattern", next_token),
             };
             Some(IlikeSelectItem { pattern: pattern? })
         } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8824,7 +8824,7 @@ impl<'a> Parser<'a> {
                 Token::SingleQuotedString(s) => s,
                 _ => return self.expected("ilike pattern", next_token),
             };
-            Some(IlikeSelectItem { pattern: pattern })
+            Some(IlikeSelectItem { pattern })
         } else {
             None
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8818,10 +8818,8 @@ impl<'a> Parser<'a> {
         &mut self,
     ) -> Result<Option<IlikeSelectItem>, ParserError> {
         let opt_ilike = if self.parse_keyword(Keyword::ILIKE) {
-            let pattern = self.parse_value()?;
-            Some(IlikeSelectItem {
-                pattern: Expr::Value(pattern),
-            })
+            let pattern = self.parse_literal_string()?;
+            Some(IlikeSelectItem { pattern })
         } else {
             None
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8821,10 +8821,10 @@ impl<'a> Parser<'a> {
         let opt_ilike = if self.parse_keyword(Keyword::ILIKE) {
             let next_token = self.next_token();
             let pattern = match next_token.token {
-                Token::SingleQuotedString(s) => Ok(s),
-                _ => self.expected("ilike pattern", next_token),
+                Token::SingleQuotedString(s) => s,
+                _ => return self.expected("ilike pattern", next_token),
             };
-            Some(IlikeSelectItem { pattern: pattern? })
+            Some(IlikeSelectItem { pattern: pattern })
         } else {
             None
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6560,6 +6560,7 @@ fn lateral_function() {
         distinct: None,
         top: None,
         projection: vec![SelectItem::Wildcard(WildcardAdditionalOptions {
+            opt_ilike: None,
             opt_exclude: None,
             opt_except: None,
             opt_rename: None,

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -148,6 +148,7 @@ fn test_select_union_by_name() {
                 distinct: None,
                 top: None,
                 projection: vec![SelectItem::Wildcard(WildcardAdditionalOptions {
+                    opt_ilike: None,
                     opt_exclude: None,
                     opt_except: None,
                     opt_rename: None,
@@ -183,6 +184,7 @@ fn test_select_union_by_name() {
                 distinct: None,
                 top: None,
                 projection: vec![SelectItem::Wildcard(WildcardAdditionalOptions {
+                    opt_ilike: None,
                     opt_exclude: None,
                     opt_except: None,
                     opt_rename: None,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1633,7 +1633,7 @@ fn test_select_wildcard_with_ilike_double_quote() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE "%id" FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected single quoted string, found: \"%id\""
+        "sql parser error: Expected ilike pattern, found: \"%id\""
     );
 }
 
@@ -1642,7 +1642,7 @@ fn test_select_wildcard_with_ilike_number() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE 42 FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected single quoted string, found: 42"
+        "sql parser error: Expected ilike pattern, found: 42"
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1642,7 +1642,7 @@ fn test_select_wildcard_with_ilike_number() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE 42 FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected literal string, found: 42"
+        "sql parser error: Expected single quoted string, found: 42"
     );
 }
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1629,11 +1629,11 @@ fn test_select_wildcard_with_ilike() {
 }
 
 #[test]
-fn test_select_wildcard_with_ilike_non_literal() {
-    let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE %id FROM tbl"#);
+fn test_select_wildcard_with_ilike_double_quote() {
+    let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE "%id" FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Expected literal string, found: %"
+        "sql parser error: Expected single quoted string, found: \"%id\""
     );
 }
 
@@ -1651,6 +1651,6 @@ fn test_select_wildcard_with_ilike_replace() {
     let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE '%id%' EXCLUDE col FROM tbl"#);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "sql parser error: Unexpected EXCLUDE"
+        "sql parser error: Expected end of statement, found: EXCLUDE"
     );
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1621,11 +1621,29 @@ fn test_select_wildcard_with_ilike() {
     let select = snowflake_and_generic().verified_only_select(r#"SELECT * ILIKE '%id%' FROM tbl"#);
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
         opt_ilike: Some(IlikeSelectItem {
-            pattern: Expr::Value(Value::SingleQuotedString("%id%".to_owned())),
+            pattern: "%id%".to_owned(),
         }),
         ..Default::default()
     });
     assert_eq!(expected, select.projection[0]);
+}
+
+#[test]
+fn test_select_wildcard_with_ilike_non_literal() {
+    let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE %id FROM tbl"#);
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Expected literal string, found: %"
+    );
+}
+
+#[test]
+fn test_select_wildcard_with_ilike_number() {
+    let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE 42 FROM tbl"#);
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Expected literal string, found: 42"
+    );
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1615,3 +1615,24 @@ fn test_select_wildcard_with_replace() {
     });
     assert_eq!(expected, select.projection[0]);
 }
+
+#[test]
+fn test_select_wildcard_with_ilike() {
+    let select = snowflake_and_generic().verified_only_select(r#"SELECT * ILIKE '%id%' FROM tbl"#);
+    let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
+        opt_ilike: Some(IlikeSelectItem {
+            pattern: Expr::Value(Value::SingleQuotedString("%id%".to_owned())),
+        }),
+        ..Default::default()
+    });
+    assert_eq!(expected, select.projection[0]);
+}
+
+#[test]
+fn test_select_wildcard_with_ilike_replace() {
+    let res = snowflake().parse_sql_statements(r#"SELECT * ILIKE '%id%' EXCLUDE col FROM tbl"#);
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Unexpected EXCLUDE"
+    );
+}


### PR DESCRIPTION
Implements parsing for `SELECT * ILIKE ...` which is valid syntax in snowflake: https://docs.snowflake.com/en/sql-reference/sql/select

Via googling, it seems like only snowflake supports this syntax. I could not find any other dialect that does. Snowflake does not allow `SELECT * ILIKE <pattern> EXCLUDE <column>` so I implemented that as well. 