### PR TITLE
[chore] add passthrough query as a tablefactor

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1135,6 +1135,12 @@ pub enum TableFactor {
         subquery: Box<Query>,
         alias: Option<TableAlias>,
     },
+    /// A pass-through query string that is not parsed.
+    /// This is useful while building/rewriting queries with a known valid SQL string and to avoid parsing it.
+    PassThroughQuery {
+        query: String,
+        alias: Option<TableAlias>,
+    },
     /// `TABLE(<expr>)[ AS <alias> ]`
     TableFunction {
         expr: Expr,
@@ -1762,6 +1768,13 @@ impl fmt::Display for TableFactor {
                     write!(f, "LATERAL ")?;
                 }
                 write!(f, "({subquery})")?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {alias}")?;
+                }
+                Ok(())
+            }
+            TableFactor::PassThroughQuery { query, alias } => {
+                write!(f, "({query})")?;
                 if let Some(alias) = alias {
                     write!(f, " AS {alias}")?;
                 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1876,6 +1876,8 @@ impl Spanned for TableFactor {
             } => subquery
                 .span()
                 .union_opt(&alias.as_ref().map(|alias| alias.span())),
+            // This is usually created at runtime, so we don't have a span for it
+            TableFactor::PassThroughQuery { query: _, alias: _ } => Span::empty(),
             TableFactor::TableFunction { expr, alias } => expr
                 .span()
                 .union_opt(&alias.as_ref().map(|alias| alias.span())),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11971,7 +11971,8 @@ impl<'a> Parser<'a> {
                         | TableFactor::Pivot { alias, .. }
                         | TableFactor::Unpivot { alias, .. }
                         | TableFactor::MatchRecognize { alias, .. }
-                        | TableFactor::NestedJoin { alias, .. } => {
+                        | TableFactor::NestedJoin { alias, .. }
+                        | TableFactor::PassThroughQuery { alias, .. } => {
                             // but not `FROM (mytable AS alias1) AS alias2`.
                             if let Some(inner_alias) = alias {
                                 return Err(ParserError::ParserError(format!(


### PR DESCRIPTION
We want to have the capability to specify subquery of a SQL string that we don't necessarily need to parse. This passthrough query will be only created at runtime and serialized as it is.
The main purpose here is performance and to avoid any potential parsing bugs with already known valid SQL.