### PR TITLE
Support for databricks JSON path syntax

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -48,6 +48,7 @@ $ cargo run --example cli - [--dialectname]
 
     let dialect: Box<dyn Dialect> = match std::env::args().nth(2).unwrap_or_default().as_ref() {
         "--ansi" => Box::new(AnsiDialect {}),
+        "--databricks" => Box::new(DatabricksDialect {}),
         "--bigquery" => Box::new(BigQueryDialect {}),
         "--postgres" => Box::new(PostgreSqlDialect {}),
         "--ms" => Box::new(MsSqlDialect {}),

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1747,7 +1747,7 @@ impl Spanned for FunctionArgumentClause {
 /// see Spanned impl for JsonPathElem for more information
 impl Spanned for JsonPath {
     fn span(&self) -> Span {
-        let JsonPath { path } = self;
+        let JsonPath { path, has_colon: _ } = self;
 
         union_spans(path.iter().map(|i| i.span()))
     }
@@ -1757,11 +1757,13 @@ impl Spanned for JsonPath {
 ///
 /// Missing spans:
 /// - [JsonPathElem::Dot]
+/// - [JsonPathElem::AllElements]
 impl Spanned for JsonPathElem {
     fn span(&self) -> Span {
         match self {
             JsonPathElem::Dot { .. } => Span::empty(),
             JsonPathElem::Bracket { key } => key.span(),
+            JsonPathElem::AllElements => Span::empty(),
         }
     }
 }

--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::dialect::Dialect;
+use crate::dialect::{Dialect, Precedence};
+use crate::parser::{Parser, ParserError};
+use crate::tokenizer::Token;
 
 /// A [`Dialect`] for [Databricks SQL](https://www.databricks.com/)
 ///
@@ -36,6 +38,19 @@ impl Dialect for DatabricksDialect {
 
     fn is_identifier_part(&self, ch: char) -> bool {
         matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_')
+    }
+
+    fn get_next_precedence(&self, parser: &Parser) -> Option<Result<u8, ParserError>> {
+        let token = parser.peek_token();
+        // : is used for JSON path access
+        match token.token {
+            Token::Colon => Some(Ok(self.prec_value(Precedence::Period))),
+            _ => None,
+        }
+    }
+
+    fn supports_semi_structured_array_all_elements(&self) -> bool {
+        true
     }
 
     fn supports_filter_during_aggregation(&self) -> bool {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -892,6 +892,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports writing `[*]` to select all elements in a JSON array.
+    fn supports_semi_structured_array_all_elements(&self) -> bool {
+        false
+    }
+
     /// Returns true if the specified keyword is reserved and cannot be
     /// used as an identifier without special handling like quoting.
     fn is_reserved_for_identifier(&self, kw: Keyword) -> bool {

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -206,6 +206,7 @@ fn test_redshift_json_path() {
                 Ident::new("c_orders")
             ])),
             path: JsonPath {
+                has_colon: false,
                 path: vec![
                     JsonPathElem::Bracket {
                         key: Expr::value(number("0"))
@@ -229,6 +230,7 @@ fn test_redshift_json_path() {
                 Ident::new("c_orders")
             ])),
             path: JsonPath {
+                has_colon: false,
                 path: vec![
                     JsonPathElem::Bracket {
                         key: Expr::value(number("0"))
@@ -255,6 +257,7 @@ fn test_redshift_json_path() {
                 Ident::new("col1")
             ])),
             path: JsonPath {
+                has_colon: false,
                 path: vec![
                     JsonPathElem::Bracket {
                         key: Expr::value(number("0"))
@@ -281,6 +284,7 @@ fn test_redshift_json_path() {
                 Ident::new("col1")
             ])),
             path: JsonPath {
+                has_colon: false,
                 path: vec![
                     JsonPathElem::Bracket {
                         key: Expr::value(number("0"))
@@ -308,6 +312,7 @@ fn test_parse_json_path_from() {
             assert_eq!(
                 json_path,
                 &Some(JsonPath {
+                    has_colon: false,
                     path: vec![
                         JsonPathElem::Bracket {
                             key: Expr::value(number("0"))
@@ -332,6 +337,7 @@ fn test_parse_json_path_from() {
             assert_eq!(
                 json_path,
                 &Some(JsonPath {
+                    has_colon: false,
                     path: vec![
                         JsonPathElem::Bracket {
                             key: Expr::value(number("0"))

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1127,6 +1127,7 @@ fn parse_semi_structured_data_traversal() {
         SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: true,
                 path: vec![JsonPathElem::Dot {
                     key: "b".to_owned(),
                     quoted: false
@@ -1143,6 +1144,7 @@ fn parse_semi_structured_data_traversal() {
         SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: true,
                 path: vec![JsonPathElem::Dot {
                     key: "my long object key name".to_owned(),
                     quoted: true
@@ -1159,6 +1161,7 @@ fn parse_semi_structured_data_traversal() {
         SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: false,
                 path: vec![JsonPathElem::Bracket {
                     key: Expr::BinaryOp {
                         left: Box::new(Expr::value(number("2"))),
@@ -1181,6 +1184,7 @@ fn parse_semi_structured_data_traversal() {
             SelectItem::UnnamedExpr(Expr::JsonAccess {
                 value: Box::new(Expr::Identifier(Ident::new("a"))),
                 path: JsonPath {
+                    has_colon: true,
                     path: vec![JsonPathElem::Dot {
                         key: "select".to_owned(),
                         quoted: false
@@ -1190,6 +1194,7 @@ fn parse_semi_structured_data_traversal() {
             SelectItem::UnnamedExpr(Expr::JsonAccess {
                 value: Box::new(Expr::Identifier(Ident::new("a"))),
                 path: JsonPath {
+                    has_colon: true,
                     path: vec![JsonPathElem::Dot {
                         key: "from".to_owned(),
                         quoted: false
@@ -1208,6 +1213,7 @@ fn parse_semi_structured_data_traversal() {
         vec![SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: true,
                 path: vec![
                     JsonPathElem::Dot {
                         key: "foo".to_owned(),
@@ -1235,6 +1241,7 @@ fn parse_semi_structured_data_traversal() {
         vec![SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: true,
                 path: vec![
                     JsonPathElem::Dot {
                         key: "foo".to_owned(),
@@ -1261,6 +1268,7 @@ fn parse_semi_structured_data_traversal() {
         vec![SelectItem::UnnamedExpr(Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: false,
                 path: vec![
                     JsonPathElem::Bracket {
                         key: Expr::value(number("0")),
@@ -1285,10 +1293,12 @@ fn parse_semi_structured_data_traversal() {
         Expr::JsonAccess {
             value: Box::new(Expr::Identifier(Ident::new("a"))),
             path: JsonPath {
+                has_colon: false,
                 path: vec![JsonPathElem::Bracket {
                     key: Expr::JsonAccess {
                         value: Box::new(Expr::Identifier(Ident::new("b"))),
                         path: JsonPath {
+                            has_colon: true,
                             path: vec![JsonPathElem::Dot {
                                 key: "c".to_owned(),
                                 quoted: false
@@ -1320,6 +1330,7 @@ fn parse_semi_structured_data_traversal() {
                 expr: Box::new(Expr::JsonAccess {
                     value: Box::new(Expr::Identifier(Ident::new("a"))),
                     path: JsonPath {
+                        has_colon: true,
                         path: vec![JsonPathElem::Dot {
                             key: "b".to_string(),
                             quoted: false
@@ -1328,6 +1339,7 @@ fn parse_semi_structured_data_traversal() {
                 })
             }),
             path: JsonPath {
+                has_colon: false,
                 path: vec![JsonPathElem::Bracket {
                     key: Expr::value(number("1"))
                 }]


### PR DESCRIPTION
dbx uses `foo:bar.baz`, like snowflake, but importantly requires the colon even when using square brackets.

I didn't add support for backtick-escaped path identifiers like `foo:\`bar\`` because the customer isn't running into it yet so it can wait.