### PR TITLE
[chore] Respect alias explicit settings in PassThoroughQuery

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1945,7 +1945,7 @@ impl fmt::Display for TableFactor {
             TableFactor::PassThroughQuery { query, alias } => {
                 write!(f, "({query})")?;
                 if let Some(alias) = alias {
-                    write!(f, " AS {alias}")?;
+                    write!(f, " {alias}")?;
                 }
                 Ok(())
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15220,6 +15220,30 @@ fn ast_with_pass_through_query() {
     };
 
     // After modifying the AST, the SQL representation should be different
+    assert_eq!(ast.to_string(), "SELECT * FROM (SELECT * FROM tx) ty");
+}
+
+#[test]
+fn ast_with_pass_through_query_with_explicit_alias() {
+    let sql = "SELECT * FROM t1 AS t2";
+    let mut ast = all_dialects().verified_stmt(sql);
+    let Statement::Query(ref mut query) = ast else {
+        panic!("Expected Query");
+    };
+    let SetExpr::Select(ref mut select) = *query.body else {
+        panic!("Expected SetExpr::Select");
+    };
+    let from = select.from.get_mut(0).unwrap();
+    from.relation = TableFactor::PassThroughQuery {
+        query: "SELECT * FROM tx".to_string(),
+        alias: Some(TableAlias {
+            explicit: true,
+            name: Ident::new("ty"),
+            columns: vec![],
+        }),
+    };
+
+    // After modifying the AST, the SQL representation should be different
     assert_eq!(ast.to_string(), "SELECT * FROM (SELECT * FROM tx) AS ty");
 }
 


### PR DESCRIPTION
We added `PassThroughQuery` for SQL element references. The Alias definition didn't use to have any notion of having explicit `AS` or not. So we were always adding `AS`. But now that it have `explicit` field, we can skip doing that and let the alias render with its own setting.