### PR TITLE
[chore] support databricks ! as synonym to not

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -36,7 +36,7 @@ pub enum UnaryOperator {
     /// `@-@` Length or circumference (PostgreSQL/Redshift geometric operator)
     /// see <https://www.postgresql.org/docs/9.5/functions-geometry.html>
     AtDashAt,
-    /// Unary logical not operator: e.g. `! false` (Hive-specific)
+    /// Unary logical not operator: e.g. `!false`
     BangNot,
     /// Bitwise Not, e.g. `~9`
     BitwiseNot,

--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -90,6 +90,11 @@ impl Dialect for DatabricksDialect {
         true
     }
 
+    /// See <https://docs.databricks.com/aws/en/sql/language-manual/functions/bangsign>
+    fn supports_bang_not_operator(&self) -> bool {
+        true
+    }
+
     /// See <https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-groupby.html>
     fn supports_group_by_with_modifier(&self) -> bool {
         true

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -111,6 +111,13 @@ fn test_databricks_exists() {
 }
 
 #[test]
+fn test_databricks_bang_not() {
+    databricks().verified_expr("!true");
+    databricks().verified_expr("!false");
+    databricks().verified_expr("!NULL");
+}
+
+#[test]
 fn test_databricks_lambdas() {
     #[rustfmt::skip]
     let sql = concat!(


### PR DESCRIPTION
It seems that Databricks support `!` as synonym to `not`. This PR adds support for that.